### PR TITLE
Avoid counter error when deck exceeds 45 slides #11

### DIFF
--- a/config/presento.sty
+++ b/config/presento.sty
@@ -54,7 +54,7 @@
   \fi
   \hfill{
     \tikz{
-      \filldraw[fill=colorblue!40, draw=colorblue!50]  (0,0) -- (0.2,0) arc (0:{\value{framenumber}*(360/(\value{totalfr}-1))}:0.2) -- (0,0);
+      \filldraw[fill=colorblue!40, draw=colorblue!50]  (0,0) -- (0.2,0) arc (0:{180 * \value{framenumber} / \value{totalfr} + 180 * \value{framenumber} / \value{totalfr}}:0.2) -- (0,0);
       \node at (0,0) {\normalsize \color{colororange}\tiny{\insertframenumber}};
     }
   }


### PR DESCRIPTION
See #11. Not sure if there is now a hard limit at 90 slides. This solution is a copy-paste from the comment on https://tex.stackexchange.com/a/284780/52459 but it works for my 50 slide deck.